### PR TITLE
Change how functions are declared

### DIFF
--- a/evaluator/builtins_test.go
+++ b/evaluator/builtins_test.go
@@ -159,7 +159,7 @@ func TestCopyBuiltin(t *testing.T) {
 	testEvalFloat(t, `copy(1.1);`, 1.1)
 	testEvalType[*object.Boolean](t, `copy(true)`, "true")
 	testEvalType[*object.String](t, `copy("Icheka")`, "Icheka")
-	testEvalType[*object.Function](t, `copy(fn() { return 1 })`, "fn() { return 1; }")
+	testEvalType[*object.Function](t, `copy(func() { return 1 })`, "func() { return 1; }")
 	testEvalType[*object.Array](t, `copy([1,2,3])`, "[1, 2, 3]")
 	testEvalType[*object.Hash](t, `copy({1:1})`, "{1: 1}")
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -279,7 +279,7 @@ if (10 > 1) {
 		},
 		{
 			`
-let f = fn(x) {
+let f = func(x) {
   return x;
   x + 10;
 };
@@ -288,7 +288,7 @@ f(10);`,
 		},
 		{
 			`
-let f = fn(x) {
+let f = func(x) {
    let result = x + 10;
    return result;
    return 10;
@@ -354,7 +354,7 @@ if (10 > 1) {
 			"identifier not found: foobar",
 		},
 		{
-			`{"name": "Monkey"}[fn(x) { x }];`,
+			`{"name": "Monkey"}[func(x) { x }];`,
 			"unusable as hash key: FUNCTION",
 		},
 		{
@@ -404,7 +404,7 @@ func TestLetStatements(t *testing.T) {
 }
 
 func TestFunctionObject(t *testing.T) {
-	input := "fn(x) { x + 2; };"
+	input := "func(x) { x + 2; };"
 
 	evaluated := testEval(input)
 	fn, ok := evaluated.(*object.Function)
@@ -433,12 +433,12 @@ func TestFunctionApplication(t *testing.T) {
 		input    string
 		expected int64
 	}{
-		{"let identity = fn(x) { x; }; identity(5);", 5},
-		{"let identity = fn(x) { return x; }; identity(5);", 5},
-		{"let double = fn(x) { x * 2; }; double(5);", 10},
-		{"let add = fn(x, y) { x + y; }; add(5, 5);", 10},
-		{"let add = fn(x, y) { x + y; }; add(5 + 5, add(5, 5));", 20},
-		{"fn(x) { x; }(5)", 5},
+		{"let identity = func(x) { x; }; identity(5);", 5},
+		{"let identity = func(x) { return x; }; identity(5);", 5},
+		{"let double = func(x) { x * 2; }; double(5);", 10},
+		{"let add = func(x, y) { x + y; }; add(5, 5);", 10},
+		{"let add = func(x, y) { x + y; }; add(5 + 5, add(5, 5));", 20},
+		{"func(x) { x; }(5)", 5},
 	}
 
 	for _, tt := range tests {
@@ -452,7 +452,7 @@ let first = 10;
 let second = 10;
 let third = 10;
 
-let ourFunction = fn(first) {
+let ourFunction = func(first) {
   let second = 20;
 
   first + second + third;
@@ -465,8 +465,8 @@ ourFunction(20) + first + second;`
 
 func TestClosures(t *testing.T) {
 	input := `
-let newAdder = fn(x) {
-  fn(y) { x + y };
+let newAdder = func(x) {
+  func(y) { x + y };
 };
 
 let addTwo = newAdder(2);

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -10,7 +10,7 @@ func TestNextToken(t *testing.T) {
 	input := `let five = 5;
 let ten = 10;
 
-let add = fn(x, y) {
+let add = func(x, y) {
   x + y;
 };
 
@@ -63,7 +63,7 @@ while
 		{token.LET, "let"},
 		{token.IDENT, "add"},
 		{token.ASSIGN, "="},
-		{token.FUNCTION, "fn"},
+		{token.FUNCTION, "func"},
 		{token.LPAREN, "("},
 		{token.IDENT, "x"},
 		{token.COMMA, ","},

--- a/object/object.go
+++ b/object/object.go
@@ -118,7 +118,7 @@ func (f *Function) Inspect() string {
 		params = append(params, p.String())
 	}
 
-	out.WriteString("fn")
+	out.WriteString("func")
 	out.WriteString("(")
 	out.WriteString(strings.Join(params, ", "))
 	out.WriteString(") {\n")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -697,7 +697,7 @@ func TestLogicalOrOperator(t *testing.T) {
 }
 
 func TestFunctionLiteralParsing(t *testing.T) {
-	input := `fn(x, y) { x + y; }`
+	input := `func(x, y) { x + y; }`
 
 	l := lexer.New(input)
 	p := New(l)
@@ -748,9 +748,9 @@ func TestFunctionParameterParsing(t *testing.T) {
 		input          string
 		expectedParams []string
 	}{
-		{input: "fn() {};", expectedParams: []string{}},
-		{input: "fn(x) {};", expectedParams: []string{"x"}},
-		{input: "fn(x, y, z) {};", expectedParams: []string{"x", "y", "z"}},
+		{input: "func() {};", expectedParams: []string{}},
+		{input: "func(x) {};", expectedParams: []string{"x"}},
+		{input: "func(x, y, z) {};", expectedParams: []string{"x", "y", "z"}},
 	}
 
 	for _, tt := range tests {

--- a/token/token.go
+++ b/token/token.go
@@ -68,7 +68,7 @@ type Token struct {
 }
 
 var keywords = map[string]TokenType{
-	"fn":     FUNCTION,
+	"func":   FUNCTION,
 	"let":    LET,
 	"true":   TRUE,
 	"false":  FALSE,


### PR DESCRIPTION
- Change 'fn' keyword to 'func'
- Allow declaring named functions without 'let'